### PR TITLE
Trailing Comma Breaks IE

### DIFF
--- a/jquery.swiftype.autocomplete.js
+++ b/jquery.swiftype.autocomplete.js
@@ -403,7 +403,7 @@
     suggestionListType: 'ul',
     suggestionListClass: 'st-autocomplete',
     resultListSelector: 'li',
-    typingDelay: 80,
+    typingDelay: 80
   };
 
 })(jQuery);


### PR DESCRIPTION
Trailing comma in `$.fn.swiftype.defaults`:

```
ERROR - Parse error. Internet Explorer has a non-standard intepretation of trailing commas. Arrays will have the wrong length and objects will not parse at all.
```
