### PR TITLE
Allow custom resultRenderFunction to access the search term

### DIFF
--- a/jquery.swiftype.autocomplete.js
+++ b/jquery.swiftype.autocomplete.js
@@ -371,7 +371,7 @@
       $list.empty();
       $this.hideList(true);
 
-      config.resultRenderFunction($this.getContext(), data);
+      config.resultRenderFunction($this.getContext(), data, term);
 
       var totalItems = $this.listResults().length;
       if ((totalItems > 0 && $this.focused()) || (config.noResultsMessage !== undefined)) {


### PR DESCRIPTION
The `processData` function's third arg takes a `term`, but it's never used. I believe it should be passed to `resultRenderFunction` so that any custom renderer can use it.
## Use case

Adding dynamic text to the results such as: _Products matching "your search term"._
