### PR TITLE
remove event listener before adding it.

### DIFF
--- a/jquery.swiftype.autocomplete.js
+++ b/jquery.swiftype.autocomplete.js
@@ -187,7 +187,8 @@
       var typingDelayPointer;
       var suppressKey = false;
       $this.lastValue = '';
-      $this.keyup(function (event) {
+      // The "off" below clears multiple handlers.
+      $this.off('keyup').keyup(function (event) {
         if (suppressKey) {
           suppressKey = false;
           return;


### PR DESCRIPTION
This prevents the user from adding two event listeners on the same input field.
