### PR TITLE
Fixed AJAX call for compatibility with jQuery 3

### DIFF
--- a/jquery.swiftype.autocomplete.js
+++ b/jquery.swiftype.autocomplete.js
@@ -318,7 +318,7 @@
       dataType: 'jsonp',
       url: endpoint,
       data: params
-    }).success(function(data) {
+    }).done(function(data) {
       var norm = normalize(term);
       if (data.record_count > 0) {
         $this.cache.put(norm, data.records);


### PR DESCRIPTION
jQuery 3 deprecated the jqXHR.success callback, which breaks the plugin.

Changing .success to .done fixes this issue.