### PR TITLE
Fixing the 404 error because of old/bad api url

### DIFF
--- a/jquery.swiftype.autocomplete.js
+++ b/jquery.swiftype.autocomplete.js
@@ -23,7 +23,7 @@
   var ident = 0;
 
   window.Swiftype = window.Swiftype || {};
-  Swiftype.root_url = Swiftype.root_url || 'https://api.swiftype.com';
+  Swiftype.root_url = Swiftype.root_url || 'https://search-api.swiftype.com';
   Swiftype.pingUrl = function(endpoint, callback) {
     var to = setTimeout(callback, 350);
     var img = new Image();
@@ -322,7 +322,7 @@
     params['per_page'] = config.resultLimit;
     params['highlight_fields'] = config.highlightFields;
 
-    var endpoint = Swiftype.root_url + '/api/v1/public/engines/suggest.json';
+    var endpoint = Swiftype.root_url + '/api/v1/public/installs/' + params['engine_key'] + '/suggest.json';
     $this.currentRequest = $.ajax({
       type: 'GET',
       dataType: 'jsonp',


### PR DESCRIPTION
#### Actual behavior:

When writing in the search input field, having a `404 not found` in the requested URL below:
```
https://api.swiftype.com/api/v1/public/engines/suggest.json?callback=jQuery3310023742832336612896_1556542682169&q=abcd&engine_key=[ENGINE_KEY_HERE]&per_page=6&_=1556542682172
```
#### Wanted behaviour:

Getting a `200` response when looking for autocomplete

#### How this PR fixes the issue ?

This pull request fixes the issue by updating the requested API url. I tested it in the project we're working on, and it worked.