### PR TITLE
Fix invalid serialization of complex object parameters

### DIFF
--- a/jquery.swiftype.autocomplete.js
+++ b/jquery.swiftype.autocomplete.js
@@ -322,12 +322,18 @@
     params['per_page'] = config.resultLimit;
     params['highlight_fields'] = config.highlightFields;
 
+    for (var prop in params) {
+        if (params.hasOwnProperty(prop) && params[prop] === undefined) {
+            delete params[prop];
+        }
+    }
+
     var endpoint = Swiftype.root_url + '/api/v1/public/engines/suggest.json';
     $this.currentRequest = $.ajax({
       type: 'GET',
       dataType: 'jsonp',
       url: endpoint,
-      data: params
+      data: $.param(params, false)
     }).done(function(data) {
       var norm = normalize(term);
       if (data.record_count > 0) {


### PR DESCRIPTION
When trying to use the code very similar to the code provided in the example:

```
var input = $('#' + SELECTORS.searchId).swiftype({
    onComplete: function(selectedItem) {
        input.val(selectedItem['title']); // Update the autocomplete dropdown's value
    },
    filters: {'page': { 'language': "en"}},
    resultLimit: 4,
    engineKey: 'MY_ENGINE_KEY'
});
```

The resulting request was (in curl format):

```
curl 'https://api.swiftype.com/api/v1/public/engines/suggest.json?callback=jQuery1124043777921080496074_1566922663009&q=confirm&engine_key=MY_ENGINE_KEY&filters=%5Bobject+Object%5D&per_page=4&_=1566922663014'
```

Note that the `{'page': { 'language': "en"}}` object is incorrectly serialized as `[object Object]`. This is a fairly common serialization issue.

This results in the following error from the API:

> `{"filters":"Value for 'filters' must be an Object."}`

I was looking into other options on how it should be serialized, because the docs don't make a lot of sense because I know you don't normally have a body in a GET request. 

I first tried something like:

```
var input = $('#' + SELECTORS.searchId).swiftype({
    onComplete: function(selectedItem) {
        input.val(selectedItem['title']); // Update the autocomplete dropdown's value
    },
    filters: JSON.stringify({'page': { 'language': "en"}}),
    resultLimit: 4,
    engineKey: 'MY_ENGINE_KEY'
});
```

This would serialize the URL parameter as a URL encoded JSON objet, But the error remained. I later determined that the correct serialization is actually the form used by jQuery's `$.param`, which will take an object like:

> `filters = {'a': 'b'}`

And serialize it as:

> `&filters[a]=b`

The solution here was to properly serialize the outgoing parameters using `$.param`. It also required me to remove any undefined config values as the defaults are not correct (since they are undefined but the API expects an object or an array in some cases).

I'm curious as to how this was ever working for anyone, as it seems to me like any time anyone tries to use something like custom filters, they will encounter this issue.