### PR TITLE
Add function to resetAutocompleteCache

### DIFF
--- a/jquery.swiftype.autocomplete.js
+++ b/jquery.swiftype.autocomplete.js
@@ -192,6 +192,13 @@
         };
       };
 
+      Swiftype.resetAutocompleteCache = function () {
+        if ($this.cache) {
+          $this.cache = new LRUCache(10);
+          $this.lastValue = null;
+          processInput($this);
+        }
+      }
 
       var typingDelayPointer;
       var suppressKey = false;


### PR DESCRIPTION
This library is very flexible, but appears to be missing the option to handle filters/facets.  If someone has partially entered a search term (and autocomplete results are showing), and then filters/facets are added or changed, the autocomplete results display inconsistently and erratically.  That is because some entries are cached prior to the filter/facet, but new requests are filtered.

The jquery.swiftype.js library has a function `Swiftype.reloadResults()` which should be called whenever a filter/facet is dynamically changed.  In the same way, when filters/facets are changed when using this code, `Swiftype.resetAutocompleteCache()` should be called to reset the cache and provide consistent autocomplete results.
